### PR TITLE
fixes redirect  from sign-in to clouds

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -21,7 +21,7 @@ class CloudStay < Sinatra::Base
     user = User.authenticate_user(username: params[:username], password: params[:password])
     if user
       session[:user_id] = user.id
-      redirect('/cloud')
+      redirect('/clouds')
     else
       flash[:notice] = 'Please check your email or password.'
       redirect('/')


### PR DESCRIPTION
What? - corrected the redirect (/cloud -> /clouds)
Why? - to link up the two pair's Tuesday work properly
Tested?  - I tested in rackup localhost